### PR TITLE
3.1

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,5 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: ["https://tippin.me/@cypher_poet"]
-
+custom: ["https://tippin.me/@cypher_poet", "https://zbd.gg/Cypherpoet"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-# Changelog
+# ♻️ Changelog
+
+## Version 3.1 - July 9, 2022
+
+- Add Support for Swift Regex
+  - Use `#4EE7FF` for `Regex Literals`.
+  - Use `#FA54BB` for `Regex Literal Operators`.
+  - Use `#FF074B` for `Regex Literal Numbers`.
+  - Use `#FF074B` for `Regex Literal Capture Names`.
+  - Use `#FF074B` for `Regex Literal Character Class Names`.
+- Use `#FA54BB` for `Attributes` to give Markdown a bit more color.
 
 ## Version 3 - December 29, 2020
 
@@ -13,4 +23,4 @@
 - Embolden "Mark" keywords.
 - Use `SF Pro Text` for comments and "Mark"s.
 - Use a bright green color for compiler flags.
-    + Not too garish &mdash; just slightly-more-conspicuous than the other primary colors in the palette 🙂.
+  - Not too garish &mdash; just slightly-more-conspicuous than the other primary colors in the palette 🙂.

--- a/Charmed Dark.xccolortheme
+++ b/Charmed Dark.xccolortheme
@@ -28,8 +28,6 @@
     <string>1 0.8 0 1</string>
     <key>DVTConsoleTextSelectionColor</key>
     <string>0.514612 0.546015 0.705882 0.313725</string>
-    <key>DVTDebuggerInstructionPointerColor</key>
-    <string>0.686928 0.321797 0.99894 1</string>
     <key>DVTFontAndColorVersion</key>
     <integer>1</integer>
     <key>DVTLineSpacing</key>
@@ -99,7 +97,7 @@
     <key>DVTSourceTextSyntaxColors</key>
     <dict>
       <key>xcode.syntax.attribute</key>
-      <string>0.509804 0.666667 1 1</string>
+      <string>1 0.0956327 0.695632 1</string>
       <key>xcode.syntax.character</key>
       <string>0.304546 0.906867 0.99953 1</string>
       <key>xcode.syntax.comment</key>
@@ -111,7 +109,7 @@
       <key>xcode.syntax.declaration.other</key>
       <string>0.77133 0.908603 0.809874 1</string>
       <key>xcode.syntax.declaration.type</key>
-      <string>0.77133 0.908603 0.809874 1</string>
+      <string>0.772549 0.909804 0.811765 1</string>
       <key>xcode.syntax.identifier.class</key>
       <string>0.989266 0.418232 0.0338797 1</string>
       <key>xcode.syntax.identifier.class.system</key>
@@ -131,7 +129,7 @@
       <key>xcode.syntax.identifier.type</key>
       <string>0.989266 0.418232 0.0338797 1</string>
       <key>xcode.syntax.identifier.type.system</key>
-      <string>0.989266 0.418232 0.0338797 1</string>
+      <string>0.988235 0.419608 0.0352941 1</string>
       <key>xcode.syntax.identifier.variable</key>
       <string>0.923668 0.989438 0.413758 1</string>
       <key>xcode.syntax.identifier.variable.system</key>
@@ -145,9 +143,19 @@
       <key>xcode.syntax.number</key>
       <string>1 0.0285367 0.295764 1</string>
       <key>xcode.syntax.plain</key>
-      <string>0.77133 0.908603 0.809874 1</string>
+      <string>0.772549 0.909804 0.811765 1</string>
       <key>xcode.syntax.preprocessor</key>
       <string>0.272541 1 0.411027 1</string>
+      <key>xcode.syntax.regex</key>
+      <string>0.305882 0.905882 1 1</string>
+      <key>xcode.syntax.regex.capturename</key>
+      <string>1 0.0285367 0.295764 1</string>
+      <key>xcode.syntax.regex.charname</key>
+      <string>1 0.027451 0.294118 1</string>
+      <key>xcode.syntax.regex.number</key>
+      <string>1 0.0285367 0.295764 1</string>
+      <key>xcode.syntax.regex.other</key>
+      <string>1 0.0939231 0.695646 1</string>
       <key>xcode.syntax.string</key>
       <string>0.304546 0.906867 0.99953 1</string>
       <key>xcode.syntax.url</key>
@@ -204,6 +212,16 @@
       <key>xcode.syntax.plain</key>
       <string>FiraCode-Retina - 15.0</string>
       <key>xcode.syntax.preprocessor</key>
+      <string>FiraCode-Retina - 15.0</string>
+      <key>xcode.syntax.regex</key>
+      <string>FiraCode-Retina - 15.0</string>
+      <key>xcode.syntax.regex.capturename</key>
+      <string>FiraCode-Retina - 15.0</string>
+      <key>xcode.syntax.regex.charname</key>
+      <string>FiraCode-Retina - 15.0</string>
+      <key>xcode.syntax.regex.number</key>
+      <string>FiraCode-Retina - 15.0</string>
+      <key>xcode.syntax.regex.other</key>
       <string>FiraCode-Retina - 15.0</string>
       <key>xcode.syntax.string</key>
       <string>FiraCode-Retina - 15.0</string>

--- a/README.md
+++ b/README.md
@@ -14,17 +14,9 @@ I hope you like it &mdash; but feel free to tweak things as needed ✌️.
   <summary>Tip</summary>
   </br>
 
-  Depending on your monitor settings, GitHub's image resolution capabilities, and, likely, my own screen capturing limitations, these images might not be showing in their "true" resolution. Try following the [installation instructions](#Installation) below and booting up a new Xcode project so see things for yourself.
+Depending on your monitor settings, GitHub's image resolution capabilities, and, likely, my own screen capturing limitations, these images might not be showing in their "true" resolution. Try following the [installation instructions](#Installation) below and booting up a new Xcode project so see things for yourself.
+
 </details>
-
-### Fonts Used
-
-- [Fira Code](https://github.com/tonsky/FiraCode) for code
-  - 14pt
-  - Retina/Medium/Bold
-  - Relaxed Line Spacing
-- SF Pro Text for Markup
-
 
 <div style="text-align: center;">
   <img src="./Screenshots/switch-statement.png" width="700"/>
@@ -41,9 +33,30 @@ I hope you like it &mdash; but feel free to tweak things as needed ✌️.
   <br/>
 </div>
 
+## ✍️ Typography
 
-## Installation
+### Main Fonts Used
 
+#### Source Code
+
+- [Fira Code](https://github.com/tonsky/FiraCode)
+  - 15 pt
+  - Retina/Medium/Bold
+  - Relaxed Line Spacing
+
+#### Markup & Markdown
+
+- SF Pro Text
+- 15 pt
+- Medium/Bold
+
+#### Console & Debugger Text
+
+- SF Mono
+- Regular
+- 13 pt
+
+## ⬇️ Installation
 
 If you haven't already done so, create a `FontAndColorThemes` directory inside of Xcode's `UserData` folder:
 
@@ -57,11 +70,8 @@ Then simply download this project and copy the [Charmed Dark.xccolortheme](./Cha
 cp Charmed\ Dark.xccolortheme ~/Library/Developer/Xcode/UserData/FontAndColorThemes/
 ```
 
-
 From there, open up Xcode and head into `Preferences` > `Themes`, and select `Charmed Dark` from the list of theme options. (If you currently have Xcode open, you'll likely need to restart it before seeing Charmed Dark appear in the menu).
 
-
-## Credits
+## 🙏 Credits
 
 Despite the previous jab I made at most dark themes, `Charmed Dark` _was_ inspired by some notable outliers &mdash; particularly [One Dark](https://github.com/bojan/xcode-one-dark) and the outstanding [Dracula](https://github.com/dracula/dracula-theme/blob/master/README.md) theme. I use Dracula as my [theme for iTerm](https://draculatheme.com/iterm/), and wouldn't hesitate to recommend it 🧛‍.
-


### PR DESCRIPTION
- Add Support for Swift Regex
  - Use `#4EE7FF` for `Regex Literals`.
  - Use `#FA54BB` for `Regex Literal Operators`.
  - Use `#FF074B` for `Regex Literal Numbers`.
  - Use `#FF074B` for `Regex Literal Capture Names`.
  - Use `#FF074B` for `Regex Literal Character Class Names`.
- Use `#FA54BB` for `Attributes` to give Markdown a bit more color.